### PR TITLE
Twitter bot fix for hall_of_fame param

### DIFF
--- a/program-list/program-list.json
+++ b/program-list/program-list.json
@@ -5436,7 +5436,7 @@
     "launch_date": "",
     "offers_bounty": "",
     "offers_swag": "",
-    "hall_of_fame": true,
+    "hall_of_fame": "partial",
     "safe_harbor": "",
     "public_disclosure": "",
     "pgp_key": "",


### PR DESCRIPTION
# Summary
Fixed offending data type in `hall_of_fame`, not complying with the schema and making the twitter bot fail. 