### PR TITLE
Toggle SAP offers_bounty to "no". SAP does not offer bounties for pub…

### DIFF
--- a/program-list.json
+++ b/program-list.json
@@ -15356,7 +15356,7 @@
         "policy_url": "https://wiki.scn.sap.com/wiki/display/PSR/Disclosure+Guidelines+for+SAP+Security+Advisories",
         "contact_url": "https://vulnerability-form.cfapps.sap.hana.ondemand.com",
         "launch_date": "",
-        "offers_bounty": "yes",
+        "offers_bounty": "no",
         "offers_swag": false,
         "hall_of_fame": "https://wiki.scn.sap.com/wiki/display/PSR/Acknowledgments+to+Security+Researchers",
         "safe_harbor": "partial",


### PR DESCRIPTION
Toggle SAP offers_bounty to "no". SAP does not offer bounties for public bounties.

The following public blog post is only about their private bug bounty program.

[https://blogs.sap.com/2021/02/23/bug-bounty-financially-motivated-crowdsourced-and-hacker-powered-application-security/](https://blogs.sap.com/2021/02/23/bug-bounty-financially-motivated-crowdsourced-and-hacker-powered-application-security/)

If you submit using the link in the article, you will not be paid for your research!