### PR TITLE
Drop Abn Amro evil clone

### DIFF
--- a/program-list.json
+++ b/program-list.json
@@ -240,22 +240,6 @@
       "contact_email":"cybersecurity@ch.abb.com"
    },
    {
-      "program_name":"ABNAMRO BANK",
-      "policy_url":"https://personal.rbs.co.uk/personal/fraud-and-security/responsible-disclosure.html",
-      "launch_date":"",
-      "offers_bounty":"no",
-      "offers_swag":false,
-      "hall_of_fame":"",
-      "safe_harbor":"none",
-      "public_disclosure":"",
-      "pgp_key":"",
-      "hiring":"",
-      "securitytxt_url":"",
-      "preferred_languages":"",
-      "policy_url_status":"alive",
-      "contact_email":"security.disclosures@rbs.co.uk"
-   },
-   {
       "program_name":"ADP",
       "policy_url":"https://www.adp.com/about-adp/data-security.aspx",
       "launch_date":"",


### PR DESCRIPTION
# Summary

Abn Amro is listed twice: as "Abn Amro" and as "ABNAMRO BANK". The second one is an evil clone, pointing to the Royal Bank of Scotland 🙃 

# Quality Assurance Checklist

| Review Items                            | Y/N |
|-----------------------------------------|-----|
| Site has a publicly known bug bounty or vulnerability disclosure program    |   inapplicable  |
| Disclosure policy is publicly available |     |
| Public URL                              |   inapplicable  |
| Submission follows the [Diodb schema](https://github.com/disclose/diodb/blob/master/program-list-schema.json)     |   yes  |

Your Twitter handle (Optional): 
