### PR TITLE
Disable the `validate_links_job` job

### DIFF
--- a/.github/workflows/validate-program-list.yml
+++ b/.github/workflows/validate-program-list.yml
@@ -29,6 +29,7 @@ jobs:
   validate_links_job:
     runs-on: ubuntu-latest
     name: validate-links job
+    if: false
     steps:
     - name: Checkout
       uses: actions/checkout@v2


### PR DESCRIPTION
Hey 👋 

I've noticed that the `validate_links_job` job [fails every time](https://github.com/disclose/diodb/actions/workflows/validate-program-list.yml) with [504 policy URLs require attention](https://github.com/disclose/diodb/runs/5962274469?check_suite_focus=true).

Since nobody seems to care about the failure, I suggest to disable the job for the time being to save mental resources needed to process a failed check and computational resources needed to run the check.

Thanks!