### PR TITLE
Add Campaign Monitor, Emma, Liveclicker and Sailthru programs.

### DIFF
--- a/program-list.json
+++ b/program-list.json
@@ -3378,6 +3378,22 @@
       "policy_url_status": "alive"
    },
    {
+      "program_name": "Campaign Monitor",
+      "policy_url": "https://www.campaignmonitor.com/trust/report-a-vulnerability/",
+      "contact_url": "https://www.campaignmonitor.com/trust/report-a-vulnerability/",
+      "launch_date": "",
+      "offers_bounty": "yes",
+      "offers_swag": false,
+      "hall_of_fame": "",
+      "safe_harbor": "full",
+      "public_disclosure": "",
+      "pgp_key": "",
+      "hiring": "",
+      "securitytxt_url": "https://www.campaignmonitor.com/.well-known/security.txt",
+      "preferred_languages": "",
+      "policy_url_status": "alive"
+   },
+   {
       "program_name": "Canva",
       "policy_url": "https://www.canva.com/security/bug-bounty/",
       "contact_url": "https://www.canva.com/security/bug-bounty/",
@@ -6333,6 +6349,23 @@
       "preferred_languages": "",
       "policy_url_status": "alive",
       "contact_email": "disclosure@ellucian.com"
+   },
+   {
+      "program_name": "Emma",
+      "policy_url": "https://myemma.com/trust/report-a-vulnerability/",
+      "contact_url": "https://myemma.com/trust/report-a-vulnerability/",
+      "launch_date": "",
+      "offers_bounty": "yes",
+      "offers_swag": false,
+      "hall_of_fame": "",
+      "safe_harbor": "full",
+      "public_disclosure": "",
+      "pgp_key": "",
+      "hiring": "",
+      "securitytxt_url": "https://myemma.com/.well-known/security.txt",
+      "preferred_languages": "",
+      "policy_url_status": "alive",
+      "contact_email": "responsibledisclosure@eneco.com"
    },
    {
       "program_name": "Eneco Group",
@@ -30154,6 +30187,22 @@
       "policy_url_status": "alive"
    },
    {
+      "program_name": "Liveclicker",
+      "policy_url": "https://www.liveclicker.com/trust/report-a-vulnerability/",
+      "contact_url": "https://www.liveclicker.com/trust/report-a-vulnerability/",
+      "launch_date": "",
+      "offers_bounty": "yes",
+      "offers_swag": false,
+      "hall_of_fame": "",
+      "safe_harbor": "full",
+      "public_disclosure": "",
+      "pgp_key": "",
+      "hiring": "",
+      "securitytxt_url": "https://www.liveclicker.com/.well-known/security.txt",
+      "preferred_languages": "",
+      "policy_url_status": "alive"
+   },
+   {
       "program_name": "livsstil.tv2.dk",
       "policy_url": "https://omtv2.tv2.dk/media/126365/tv_2_responsible_disclosure.pdf",
       "launch_date": "",
@@ -33111,6 +33160,22 @@
       "preferred_languages": "",
       "policy_url_status": "alive",
       "contact_email": "rd@bol.com"
+   },
+   {
+      "program_name": "Sailthru",
+      "policy_url": "https://www.sailthru.com/trust/report-a-vulnerability/",
+      "contact_url": "https://www.sailthru.com/trust/report-a-vulnerability/",
+      "launch_date": "",
+      "offers_bounty": "yes",
+      "offers_swag": false,
+      "hall_of_fame": "",
+      "safe_harbor": "full",
+      "public_disclosure": "",
+      "pgp_key": "",
+      "hiring": "",
+      "securitytxt_url": "https://www.sailthru.com/.well-known/security.txt",
+      "preferred_languages": "",
+      "policy_url_status": "alive"
    },
    {
       "program_name": "sandbox.paypal.com",


### PR DESCRIPTION
# Summary
Adding the Campaign Monitor, Emma, Liveclicker and Sailthru vulnerability programs to the program list.

# Quality Assurance Checklist
< Confirmation of this pull request meeting the following requirements, prior to merge > 

| Review Items                            | Y/N |
|-----------------------------------------|-----|
| Site has a publicly known bug bounty or vulnerability disclosure program    |  Y |
| Disclosure policy is publicly available |  Y  |
| Public URL  CM                         |  https://www.campaignmonitor.com/policies/#safe-harbor-policy  |
| Public URL  EM                         |  https://myemma.com/trust/security/  |
| Public URL  LC                          |  https://www.liveclicker.com/privacy-policy/#priv-section-6  |
| Public URL  ST                          |  https://www.sailthru.com/trust/security/  |
| Submission follows the [Diodb schema](https://github.com/disclose/diodb/blob/master/program-list-schema.json)     |  Y  |

Your Twitter handle (Optional): 
None