### PR TITLE
fixed facebook's policy url

### DIFF
--- a/program-list.json
+++ b/program-list.json
@@ -6863,8 +6863,8 @@
    },
    {
       "program_name": "Facebook",
-      "policy_url": "https://www.facebook.com/BugBounty/",
-      "contact_url": "https://www.facebook.com/BugBounty/",
+      "policy_url": "https://www.facebook.com/whitehat",
+      "contact_url": "https://www.facebook.com/whitehat/report/",
       "launch_date": "",
       "offers_bounty": "yes",
       "offers_swag": false,


### PR DESCRIPTION
# Summary
https://www.facebook.com/BugBounty/ is the facebook page for the bug bounty program but security policy is at https://www.facebook.com/whitehat.

# Quality Assurance Checklist
Confirmation of this pull request meeting the following requirements, prior to merge
 - [x] Site has a publicly known bug bounty or vulnerability disclosure program 
 - [x] Disclosure policy is publicly available
 - [x] Public URL                              |
 - [x] Submission follows the [Diodb schema](https://github.com/disclose/diodb/blob/master/program-list-schema.json) 


Your Twitter handle (Optional): @0xcrypto
