### PR TITLE
fix: typo in current url of program name "Target"

### DIFF
--- a/program-list.json
+++ b/program-list.json
@@ -18909,7 +18909,7 @@
    {
       "program_name": "Target",
       "policy_url": "https://security.target.com/vdp/",
-      "contact_url": "ttps://security.target.com/vdp/",
+      "contact_url": "https://security.target.com/vdp/",
       "contact_email": "security@target.com",
       "offers_bounty": "no",
       "offers_swag": false,


### PR DESCRIPTION
# Summary
Changes the typo error in current url of program name "Target".