### PR TITLE
Update Fastmail's VDP details

### DIFF
--- a/program-list.json
+++ b/program-list.json
@@ -7169,20 +7169,20 @@
       "contact_email": "security@farm.bot"
    },
    {
-      "program_name": "FastMail",
-      "policy_url": "https://www.fastmail.com/about/bugbounty.html",
+      "program_name": "Fastmail",
+      "policy_url": "https://www.fastmail.com/bug-bounty/",
       "launch_date": "",
       "offers_bounty": "yes",
       "offers_swag": false,
-      "hall_of_fame": "",
+      "hall_of_fame": "https://www.fastmail.com/bug-bounty/",
       "safe_harbor": "none",
-      "public_disclosure": "",
+      "public_disclosure": "co-ordinated",
       "pgp_key": "",
       "hiring": "",
       "securitytxt_url": "",
-      "preferred_languages": "",
+      "preferred_languages": "en",
       "policy_url_status": "alive",
-      "contact_email": "bugreport@fastmail.com"
+      "contact_email": "security@fastmailteam.com"
    },
    {
       "program_name": "Fastly",


### PR DESCRIPTION
# Summary

Update URL, email, and formatting of Fastmail's name to match the current policy as per https://www.fastmail.com/bug-bounty/

# Quality Assurance Checklist

| Review Items                            | Y/N |
|-----------------------------------------|-----|
| Site has a publicly known bug bounty or vulnerability disclosure program    | Y |
| Disclosure policy is publicly available | Y |
| Public URL | Y |
| Submission follows the [Diodb schema](https://github.com/disclose/diodb/blob/master/program-list-schema.json) | Y |