### PR TITLE
Remove ISC2

### DIFF
--- a/program-list.json
+++ b/program-list.json
@@ -1,21 +1,5 @@
 [
    {
-      "program_name": "(ISC)2",
-      "policy_url": "https://bugcrowd.com/isc2",
-      "contact_url": "https://bugcrowd.com/isc2/report",
-      "launch_date": "",
-      "offers_bounty": "no",
-      "offers_swag": false,
-      "hall_of_fame": "",
-      "safe_harbor": "partial",
-      "public_disclosure": "",
-      "pgp_key": "",
-      "hiring": "",
-      "securitytxt_url": "",
-      "preferred_languages": "",
-      "policy_url_status": "alive"
-   },
-   {
       "program_name": ".nz Registry",
       "policy_url": "https://registry.internetnz.nz/about/vulnerability-disclosure-policy/",
       "launch_date": "",


### PR DESCRIPTION
ISC2 no longer runs a security program, and this link goes to a closed engagement.

# Summary
Removes ISC2

# Quality Assurance Checklist

| Review Items                            | Y/N |
|-----------------------------------------|-----|
| Site has a publicly known bug bounty or vulnerability disclosure program    |  N   |
| Disclosure policy is publicly available |  N   |
| Public URL                              |  N/A   |
| Submission follows the [Diodb schema](https://github.com/disclose/diodb/blob/master/program-list-schema.json)     |   Y  |

Your Twitter handle (Optional): arcwhite
