### PR TITLE
add ampcode.com by sourcegraph

### DIFF
--- a/program-list.json
+++ b/program-list.json
@@ -1156,6 +1156,22 @@
       "policy_url_status": "alive"
    },
    {
+      "program_name": "AmpCode.com",
+      "policy_url": "https://ampcode.com/security/",
+      "launch_date": "",
+      "offers_bounty": "yes",
+      "offers_swag": false,
+      "hall_of_fame": "https://ampcode.com/security/",
+      "safe_harbor": "",
+      "public_disclosure": "",
+      "pgp_key": "",
+      "hiring": "https://sourcegraph.com/jobs",
+      "securitytxt_url": "https://ampcode.com/.well-known/security.txt",
+      "preferred_languages": "en",
+      "policy_url_status": "alive",
+      "contact_email": "security@sourcegraph.com"
+   },
+   {
       "program_name": "Analog Devices",
       "policy_url": "https://www.analog.com/en/support/technical-support/product-security-response-center/vulnerability-disclosure-policy.html",
       "launch_date": "",
@@ -34092,6 +34108,22 @@
       "policy_url_status": "alive"
    },
    {
+      "program_name": "raidboxes.io",
+      "policy_url": "https://raidboxes.io/vulnerability-disclosure-program/",
+      "launch_date": "",
+      "offers_bounty": "",
+      "offers_swag": "",
+      "hall_of_fame": "yes",
+      "safe_harbor": "yes",
+      "public_disclosure": "",
+      "pgp_key": "",
+      "hiring": "https://raidboxes.io/company/careers/",
+      "securitytxt_url": "https://raidboxes.io/security.txt",
+      "preferred_languages": "en",
+      "policy_url_status": "alive",
+      "contact_email": "security@raidboxes.io"
+   },
+   {
       "program_name": "rawfury.atlassian.net",
       "policy_url": "https://www.atlassian.com/trust/security/report-a-vulnerability",
       "contact_url": "https://www.atlassian.com/trust/security/report-a-vulnerability",
@@ -38278,21 +38310,5 @@
       "preferred_languages": "",
       "policy_url_status": "alive",
       "contact_email": "security@tv2.dk"
-   },
-   {
-      "program_name": "raidboxes.io",
-      "policy_url": "https://raidboxes.io/vulnerability-disclosure-program/",
-      "launch_date": "",
-      "offers_bounty": "",
-      "offers_swag": "",
-      "hall_of_fame": "yes",
-      "safe_harbor": "yes",
-      "public_disclosure": "",
-      "pgp_key": "",
-      "hiring": "https://raidboxes.io/company/careers/",
-      "securitytxt_url": "https://raidboxes.io/security.txt",
-      "preferred_languages": "en",
-      "policy_url_status": "alive",
-      "contact_email": "security@raidboxes.io"
    }
 ]


### PR DESCRIPTION
# Summary

- Adds `ampcode.com` to the DIODB. 
- Performed `tools/format.sh` on the program database which resulted in `raidboxes.io` being corrected in positioning as well.

# Quality Assurance Checklist
< Confirmation of this pull request meeting the following requirements, prior to merge > 

| Review Items                            | Y/N |
|-----------------------------------------|-----|
| Site has a publicly known bug bounty or vulnerability disclosure program    |   Y  |
| Disclosure policy is publicly available |  Y   |
| Public URL                              |  Y   |
| Submission follows the [Diodb schema](https://github.com/disclose/diodb/blob/master/program-list-schema.json)     |  Y  |

Your Twitter handle (Optional): `ampcode`
